### PR TITLE
Add Stripe subscription management

### DIFF
--- a/Tezrisat_Backend/api/migrations/0003_subscription.py
+++ b/Tezrisat_Backend/api/migrations/0003_subscription.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0002_remove_microcoursesection_quiz_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Subscription',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('stripe_subscription_id', models.CharField(max_length=255)),
+                ('status', models.CharField(default='active', max_length=50)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='subscriptions', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/Tezrisat_Backend/api/models.py
+++ b/Tezrisat_Backend/api/models.py
@@ -12,6 +12,18 @@ class Payment(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     email = models.EmailField()
 
+
+class Subscription(models.Model):
+    """Record details of a Stripe subscription."""
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="subscriptions")
+    stripe_subscription_id = models.CharField(max_length=255)
+    status = models.CharField(max_length=50, default="active")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"Subscription {self.stripe_subscription_id} for {self.user.username}"
+
 class UserProfile(models.Model):
     PLAN_CHOICES = (
         ('free', 'Free'),

--- a/Tezrisat_Backend/api/serializers.py
+++ b/Tezrisat_Backend/api/serializers.py
@@ -2,7 +2,15 @@ import logging
 from django.contrib.auth.models import User
 from rest_framework import serializers, generics
 from rest_framework.permissions import IsAuthenticated
-from api.models import Microcourse, MicrocourseSection, GlossaryTerm, QuizQuestion, RecallNote, Payment
+from api.models import (
+    Microcourse,
+    MicrocourseSection,
+    GlossaryTerm,
+    QuizQuestion,
+    RecallNote,
+    Payment,
+    Subscription,
+)
 
 
 # serializers.py
@@ -10,6 +18,18 @@ class PaymentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Payment
         fields = ['id', 'amount', 'currency', 'stripe_payment_id', 'created_at', 'email']
+
+
+class SubscriptionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Subscription
+        fields = [
+            'id',
+            'stripe_subscription_id',
+            'status',
+            'created_at',
+        ]
+        extra_kwargs = {'user': {'read_only': True}}
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:

--- a/Tezrisat_Backend/api/urls.py
+++ b/Tezrisat_Backend/api/urls.py
@@ -2,7 +2,12 @@ from django.urls import path, re_path
 
 
 from . import views
-from .views import PaymentListView, CreatePaymentIntentView
+from .views import (
+    PaymentListView,
+    CreatePaymentIntentView,
+    CancelSubscriptionView,
+    UpdateSubscriptionView,
+)
 
 # URLConfiguration
 urlpatterns = [
@@ -25,6 +30,8 @@ urlpatterns = [
 
     path("payment/", PaymentListView.as_view(), name="payment-list"),
     path("create-payment-intent/", CreatePaymentIntentView.as_view(), name="create-payment-intent"),
+    path("cancel-subscription/", CancelSubscriptionView.as_view(), name="cancel-subscription"),
+    path("update-subscription/", UpdateSubscriptionView.as_view(), name="update-subscription"),
 
 ]
 

--- a/Tezrisat_Backend/api/views.py
+++ b/Tezrisat_Backend/api/views.py
@@ -51,6 +51,7 @@ from .models import (
     RecallNote,
     UserProfile,
     Payment,
+    Subscription,
 
 )
 from .serializers import (
@@ -58,6 +59,7 @@ from .serializers import (
     MicrocourseSerializer,
     MicrocourseSectionSerializer,
     PaymentSerializer,
+    SubscriptionSerializer,
 
 )
 
@@ -103,6 +105,53 @@ class CreatePaymentIntentView(APIView):
                                      'payment': serializer.data
                                      }, status=status.HTTP_201_CREATED)
             return JsonResponse({'error': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+        except stripe.error.StripeError as e:
+            return JsonResponse({'error': str(e)}, status=400)
+
+
+class CancelSubscriptionView(APIView):
+    """Cancel an active Stripe subscription."""
+
+    def post(self, request):
+        subscription_id = request.data.get('subscription_id')
+        if not subscription_id:
+            return JsonResponse({'error': 'subscription_id is required'}, status=400)
+        try:
+            subscription = stripe.Subscription.delete(subscription_id)
+            Subscription.objects.filter(stripe_subscription_id=subscription_id).update(status=subscription.status)
+            serializer = SubscriptionSerializer(data={
+                'stripe_subscription_id': subscription.id,
+                'status': subscription.status,
+            })
+            if serializer.is_valid():
+                # Only save if not exists
+                Subscription.objects.update_or_create(
+                    stripe_subscription_id=subscription.id,
+                    defaults={'status': subscription.status, 'user': request.user}
+                )
+            return JsonResponse({'status': subscription.status})
+        except stripe.error.StripeError as e:
+            return JsonResponse({'error': str(e)}, status=400)
+
+
+class UpdateSubscriptionView(APIView):
+    """Update subscription plan or metadata using Stripe."""
+
+    def post(self, request):
+        subscription_id = request.data.get('subscription_id')
+        new_price_id = request.data.get('new_price_id')
+        if not subscription_id or not new_price_id:
+            return JsonResponse({'error': 'subscription_id and new_price_id are required'}, status=400)
+        try:
+            sub = stripe.Subscription.retrieve(subscription_id)
+            item_id = sub['items']['data'][0].id
+            updated = stripe.Subscription.modify(
+                subscription_id,
+                items=[{'id': item_id, 'price': new_price_id}],
+                proration_behavior='create_prorations',
+            )
+            Subscription.objects.filter(stripe_subscription_id=subscription_id).update(status=updated.status)
+            return JsonResponse({'status': updated.status})
         except stripe.error.StripeError as e:
             return JsonResponse({'error': str(e)}, status=400)
 

--- a/Tezrisat_Frontend/tezrisat_frontend/src/App.tsx
+++ b/Tezrisat_Frontend/tezrisat_frontend/src/App.tsx
@@ -18,6 +18,7 @@ import Pricing from "./pages/Pricing.tsx";
 import AboutPage from "./pages/About.tsx";
 import PaymentPage from "./pages/PaymentPage.tsx";
 import StripeSuccessPage from "./pages/StripeSuccessPage.tsx";
+import SubscriptionManagement from "./pages/SubscriptionManagement.tsx";
 
 // @ts-ignore
 function Logout() {
@@ -57,6 +58,11 @@ function App() {
                     <Route path="/plans" element={
                         <ProtectedRoute>
                             <Plans/>
+                        </ProtectedRoute>
+                    }/>
+                    <Route path="/subscription" element={
+                        <ProtectedRoute>
+                            <SubscriptionManagement/>
                         </ProtectedRoute>
                     }/>
                     <Route path="/payment" element={

--- a/Tezrisat_Frontend/tezrisat_frontend/src/components/Navigation.tsx
+++ b/Tezrisat_Frontend/tezrisat_frontend/src/components/Navigation.tsx
@@ -8,6 +8,7 @@ import {
   LogOut,
   Menu,
   Moon,
+  RefreshCw,
   Sun,
 } from "lucide-react";
 import {Link, useNavigate} from "react-router-dom";
@@ -123,6 +124,15 @@ const Navigation = ({ isSidebarOpen, setIsSidebarOpen }: { isSidebarOpen: boolea
         <NavItem
           icon={<CreditCard className="w-5 h-5" />}
           label="Upgrade"
+          onClick={() => {}}
+          isOpen={isSidebarOpen}
+        />
+      </Link>
+
+      <Link to="/subscription">
+        <NavItem
+          icon={<RefreshCw className="w-5 h-5" />}
+          label="Subscription"
           onClick={() => {}}
           isOpen={isSidebarOpen}
         />

--- a/Tezrisat_Frontend/tezrisat_frontend/src/pages/SubscriptionManagement.tsx
+++ b/Tezrisat_Frontend/tezrisat_frontend/src/pages/SubscriptionManagement.tsx
@@ -1,0 +1,94 @@
+import { FC, useState } from "react";
+import api from "../api";
+// @ts-ignore
+import { Button } from "@/components/ui/button";
+// @ts-ignore
+import { Input } from "@/components/ui/input";
+// @ts-ignore
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import Background from "../components/Background";
+import Navigation from "../components/Navigation";
+
+const SubscriptionManagement: FC = () => {
+  const [subscriptionId, setSubscriptionId] = useState("");
+  const [newPriceId, setNewPriceId] = useState("");
+  const [statusMessage, setStatusMessage] = useState("");
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [loading, setLoading] = useState(false);
+
+  const handleCancel = async () => {
+    try {
+      setLoading(true);
+      const res = await api.post(`/api/cancel-subscription/`, {
+        subscription_id: subscriptionId,
+      });
+      setStatusMessage(res.data.status || "Cancelled");
+    } catch (err: any) {
+      setStatusMessage(err.message || "Error cancelling subscription");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUpdate = async () => {
+    try {
+      setLoading(true);
+      const res = await api.post(`/api/update-subscription/`, {
+        subscription_id: subscriptionId,
+        new_price_id: newPriceId,
+      });
+      setStatusMessage(res.data.status || "Updated");
+    } catch (err: any) {
+      setStatusMessage(err.message || "Error updating subscription");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex bg-gradient-to-br from-teal-300 to-teal-500 text-gray-800">
+      <Background />
+      <Navigation isSidebarOpen={isSidebarOpen} setIsSidebarOpen={setIsSidebarOpen} />
+      <main className="flex-1 p-6 ml-20" style={{ marginLeft: isSidebarOpen ? 256 : 80 }}>
+        <Card className="max-w-lg mx-auto bg-white/40 backdrop-blur-sm shadow-xl rounded-3xl">
+          <CardHeader>
+            <CardTitle className="text-2xl text-teal-900">Manage Subscription</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="subid" className="text-teal-800">Subscription ID</label>
+              <Input
+                id="subid"
+                value={subscriptionId}
+                onChange={(e) => setSubscriptionId(e.target.value)}
+                className="bg-white/20 w-full"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="priceid" className="text-teal-800">New Price ID</label>
+              <Input
+                id="priceid"
+                value={newPriceId}
+                onChange={(e) => setNewPriceId(e.target.value)}
+                className="bg-white/20 w-full"
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button onClick={handleCancel} disabled={loading} className="bg-teal-600 hover:bg-teal-700 text-white">
+                Cancel
+              </Button>
+              <Button onClick={handleUpdate} disabled={loading} className="bg-teal-600 hover:bg-teal-700 text-white">
+                Update
+              </Button>
+            </div>
+            {statusMessage && (
+              <p className="text-teal-900 font-semibold">{statusMessage}</p>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+};
+
+export default SubscriptionManagement;


### PR DESCRIPTION
## Summary
- create `Subscription` model and migration
- provide serializer for subscriptions
- add CancelSubscriptionView and UpdateSubscriptionView endpoints
- wire up subscription URLs
- add SubscriptionManagement page and route
- link subscription page in navigation

## Testing
- `pytest -q`
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py migrate` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6845e701a3a8832a9b07148355e4d5d4